### PR TITLE
feat: dso-1186. Extend 'envsubst' subcommand. Unit tests added

### DIFF
--- a/subcmds/envsubst.py
+++ b/subcmds/envsubst.py
@@ -31,6 +31,7 @@ Replace ENV vars in all xml manifest files
 
 Finds all XML files in the manifests and replaces environment variables with values.
 """
+    path = '.repo/manifests/**/*.xml'
 
     # def _Options(self, p):
     #     p.add_option(
@@ -59,41 +60,94 @@ Finds all XML files in the manifests and replaces environment variables with val
             args: Positional args.  Can be a list of projects to list, or empty.
         """
         print(f"Executing envsubst {opt}, {args}")
-        path = '.repo/manifests/**/*.xml'
-        files = glob.glob(path, recursive=True)
+        files = glob.glob(self.path, recursive=True)
 
         for file in files:
             print(file)
             if os.path.getsize(file) > 0:
                 self.EnvSubst(file)
 
-
     def EnvSubst(self, infile):
         doc = minidom.parse(infile)
+        self.search_replace_placeholders(doc)
+        self.inject_attrbutes(doc)
+        # backup file before we modified it - for troubleshooting
+        os.rename(infile, infile + '.bak')
+        self.save(infile,doc)
 
-        # Replace environment variables in all element texts and attribute values
-        for elem in doc.getElementsByTagName('*'):
-            for key, value in elem.attributes.items():
-                # Check if the attribute value contains an environment variable
-                if '$' in value:
-                    # Replace the environment variable with its value
-                    elem.setAttribute(key, os.path.expandvars(value))
-            if elem.firstChild and elem.firstChild.nodeType == elem.TEXT_NODE and '$' in elem.firstChild.nodeValue:
-                # Replace the environment variable with its value
-                elem.firstChild.nodeValue = os.path.expandvars(
-                    elem.firstChild.nodeValue)
-
-        pretty_print = lambda data: '\n'.join([
+    def save(self,outfile,doc):
+        """
+        Save the modified XML document with comments and the XML header
+        """
+        def pretty_print(data): return '\n'.join([
             line
             for line in parseString(data).toprettyxml(indent=' ' * 2).split('\n')
             if line.strip()
         ])
-
-        # Save the modified XML document with comments and the XML header
-        os.rename(infile, infile + '.bak')
-
-        with open(infile, 'wb') as f:
+        with open(outfile, 'wb') as f:
             f.write(str.encode(pretty_print(doc.toprettyxml(encoding="utf-8"))))
-            #f.write(doc.toprettyxml(encoding="utf-8"))
         f.writelines
         f.close
+
+    def search_replace_placeholders(self, doc):
+        """
+        Replace in all element texts and attribute values any ${PLACEHOLDER} by value as returned from #resolveVariable
+        """
+        for elem in doc.getElementsByTagName('*'):
+            for key, value in elem.attributes.items():
+                # Check if the attribute value contains an environment variable
+                if self.is_placeholder_detected(value):
+                    # Replace the environment variable with its value
+                    elem.setAttribute(key, self.resolve_variable(value))
+            if elem.firstChild and elem.firstChild.nodeType == elem.TEXT_NODE and self.is_placeholder_detected(elem.firstChild.nodeValue):
+                # Replace the environment variable with its value
+                elem.firstChild.nodeValue = self.resolve_variable(
+                    elem.firstChild.nodeValue)
+
+    def is_placeholder_detected(self, value):
+        return '$' in value
+
+    def resolve_variable(self, var_name):
+        """
+        resolves variables from OS env vars
+        """
+        return os.path.expandvars(var_name)
+
+    def inject_attrbutes(self, doc):
+        """
+        When encounters XML element <any_element attrname='any value' dso_override_attrbiute_attrname="replacement">
+        or <any_element  dso_override_attrbiute_attrname="replacement">
+        Replace it by <any_element attrname="replacement">
+        """
+        for elem in doc.getElementsByTagName('*'):
+            while self.attr_2_override_detected(elem):
+                override_info = self.get_next_attr_override(elem)
+                self.inject_or_replace(elem, override_info[0], override_info[1])
+                elem.removeAttribute(override_info[2])
+
+    def attr_2_override_detected(self, elem) -> bool:
+        for key, value in elem.attributes.items():
+            if key.startswith('dso_override_attrbiute_'):
+                return True
+        return False
+
+    def get_next_attr_override(self, node) -> [str, str, str]:
+        """
+        when node is <any_element attrname='any value' dso_override_attrbiute_attrname="replacement">
+        returns ['attrname','replacement','dso_override_attrbiute_attrname'] 
+        otherwise returns an empty array
+        """
+        for key, value in node.attributes.items():
+            if key.startswith('dso_override_attrbiute_'):
+                attr_2_override = key[len('dso_override_attrbiute_'):]
+                attr_2_override_value = value
+                attr_2_delete = key
+                return [attr_2_override, attr_2_override_value, attr_2_delete]
+        return []
+
+    def inject_or_replace(self, elem, attr_name, attr_value) -> None:
+        if self.is_placeholder_detected(attr_value):
+            return
+        if elem.hasAttribute(attr_name):
+            elem.removeAttribute(attr_name)
+        elem.setAttribute(attr_name, attr_value)

--- a/tests/test_subcmds.py
+++ b/tests/test_subcmds.py
@@ -28,7 +28,7 @@ class AllCommands(unittest.TestCase):
         # NB: We don't test all subcommands as we want to avoid "change
         # detection" tests, so we just look for the most common/important ones
         # here that are unlikely to ever change.
-        for cmd in {"cherry-pick", "help", "init", "start", "sync", "upload"}:
+        for cmd in {"cherry-pick", "help", "init", "start", "sync", "upload", "envsubst"}:
             self.assertIn(cmd, subcmds.all_commands)
 
     def test_naming(self):

--- a/tests/test_subcmds_envsubst.py
+++ b/tests/test_subcmds_envsubst.py
@@ -1,0 +1,165 @@
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unittests for the subcmds/envsubst.py module."""
+
+import os
+import unittest
+import unittest.mock
+from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import call
+
+from subcmds import envsubst
+
+
+def _mock_os_env_var_resolve(var_name):
+    if var_name == '${GITBASE}':
+        return 'fake_gitbase'
+    elif var_name == '${GITREV}':
+        return 'fake_gitrev'
+    elif var_name == '${TEST}':
+        return 'test'
+    else:
+        return os.path.expandvars(var_name)
+
+
+class EnvsubstCommand(unittest.TestCase):
+    """Test envsubst subcommand"""
+    mock_top_level_manifest_file_content = r"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="launch-dso-platform" fetch="${GITBASE}" revision="${GITREV}"/>
+  <!-- <default remote="launch-dso-platform" revision="update" /> -->
+</manifest>
+"""
+    mock_expected_top_level_manifest_file_overwritten_content = b"""<?xml version="1.0" ?>
+<manifest>
+  <remote name="launch-dso-platform" fetch="fake_gitbase" revision="fake_gitrev"/>
+  <!-- <default remote="launch-dso-platform" revision="update" /> -->
+</manifest>"""
+
+    mock_top_level_manifest_no_local_override_supplied_file_content = r"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="launch-dso-platform" fetch="${GITBASE_NOT_EXISTS}" revision="${GITREV}"/>
+  <!-- <default remote="launch-dso-platform" revision="update" /> -->
+</manifest>
+"""
+    mock_expected_top_level_manifest_no_local_override_supplied_file_overwritten_content = b"""<?xml version="1.0" ?>
+<manifest>
+  <remote name="launch-dso-platform" fetch="${GITBASE_NOT_EXISTS}" revision="fake_gitrev"/>
+  <!-- <default remote="launch-dso-platform" revision="update" /> -->
+</manifest>"""
+
+    mock_2nd_level_manifest_file_content = r"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" dso_override_attrbiute_revision="${GITREV}">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>
+"""
+    mock_expected_2nd_level_manifest_file_overwritten_content = b"""<?xml version="1.0" ?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" revision="fake_gitrev">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile"/>
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>"""
+
+    mock_2nd_level_manifest_negative_file_content = r"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" dso_override_attrbiute_revision="${GITREV_NOT_SET}">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>
+"""
+    mock_expected_2nd_level_manifest_negative_file_overwritten_content = b"""<?xml version="1.0" ?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile"/>
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>"""
+
+    mock_2nd_level_manifest_existing_attr_file_content = r"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" revision="1.2.3" dso_override_attrbiute_revision="${GITREV}">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>
+"""
+    mock_expected_2nd_level_manifest_existing_attr_file_overwritten_content = b"""<?xml version="1.0" ?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" revision="fake_gitrev">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile"/>
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>"""
+
+    mock_2nd_level_manifest_multi_attrs_file_content = r"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" revision="1.2.3" dso_override_attrbiute_revision="${GITREV}" dso_override_attrbiute_dest-branch="${TEST}">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>
+"""
+    mock_expected_2nd_level_manifest_multi_attrs_file_overwritten_content = b"""<?xml version="1.0" ?>
+<manifest>
+  <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" revision="fake_gitrev" dest-branch="test">
+    <linkfile src="linkfiles/Makefile" dest="components/Makefile"/>
+    <!-- <linkfile src="artifacts/terraform_modules/Makefile" dest="components/terraform_modules/Makefile" /> -->
+  </project>
+</manifest>"""
+
+
+    def setUp(self):
+        self.cmd = envsubst.Envsubst()
+
+    def test_replacement_basic(self):
+        """Check baseline xml attr value string replacement """
+        self.util_generic_test(self.mock_top_level_manifest_file_content,self.mock_expected_top_level_manifest_file_overwritten_content)
+
+    def test_replacement_when_no_local_overrides_requested(self):
+        """Check  xml attr value replacement when no local OS substitutions supplied """
+        self.util_generic_test(self.mock_top_level_manifest_no_local_override_supplied_file_content,self.mock_expected_top_level_manifest_no_local_override_supplied_file_overwritten_content)
+
+    def test_attr_injection_basic(self):
+        """Check xml attr injection from override configuration"""
+        self.util_generic_test(self.mock_2nd_level_manifest_file_content,self.mock_expected_2nd_level_manifest_file_overwritten_content)
+
+    def test_attr_injection_basic_negative(self):
+        """Check xml attr injection from override configuration"""
+        self.util_generic_test(self.mock_2nd_level_manifest_negative_file_content,self.mock_expected_2nd_level_manifest_negative_file_overwritten_content)
+
+    def test_attr_injection_attr_already_exists(self):
+        """Check xml attr override when attr already exists"""
+        self.util_generic_test(self.mock_2nd_level_manifest_existing_attr_file_content,self.mock_expected_2nd_level_manifest_existing_attr_file_overwritten_content)
+
+    def test_attr_injection_multi_attrs(self):
+        """Check xml attr override when attr already exists"""
+        self.util_generic_test(self.mock_2nd_level_manifest_multi_attrs_file_content,self.mock_expected_2nd_level_manifest_multi_attrs_file_overwritten_content)
+                
+    def util_generic_test(self,input_file_content,expected_file_content):
+        """
+        generic test fixture test for expected output vs actual
+        """
+        with patch('os.rename') as rename:
+            with patch('builtins.open', new=mock_open(read_data=input_file_content)) as mocked_file:
+                self.cmd.resolve_variable = _mock_os_env_var_resolve
+                self.cmd.EnvSubst("mock-ignored.xml")
+                self.assertEqual(rename.call_args_list,[call('mock-ignored.xml', 'mock-ignored.xml.bak')],"test of Manifest backup before overwrite")
+                mocked_file().write.assert_called_once_with(
+                    expected_file_content)


### PR DESCRIPTION
- Intention is Version control multi components living in multi repos
- By keeping XML manifest for them in a <super repository>/manifests/entry.xml
- Versioned per se by git tag on <super repository>
- allow engineer override version of any component(s)

**Example:**
```
 <project name='xyz' dso_override_attrbiute_revision='${XYZ_VER}'>
```
OR
```
 <project name='xyz' revision='a default version' dso_override_attribute_revision='${XYZ_VER}'>
```
After
```
XYZ_VER=1.2.3 repo envsubst
```
 results in
``` 
<project name='xyz' revision='1.2.3'>
```
Any attribute whose name starts from dso_override_attribute_SOMETHING='{REPLACE_ME}' commands the `repo envsubst` to Upsert an attribute named SOMETHING with value from OS env var REPLACE_ME.
If no OS env var supplied - no upsert.

Existing at this moment functionality preserved

![CAF - repo-tool drawio](https://github.com/nexient-llc/git-repo/assets/120601532/1c3d9fd4-3360-433e-ac8e-a5f728518bda)

Tested on python ver from 3.6 (lowest supported by the 'repo') 3.7, 3.11 
<img width="1230" alt="RepoToolUnitTestPatchOnlyPython3 6" src="https://github.com/nexient-llc/git-repo/assets/120601532/031ce59c-e589-43c3-b1c9-8db1269df320">
3 unit tests from 228 are failing - this is not Launch patch code but upstream code base.
<img width="1154" alt="RepoToolUnitTestAll" src="https://github.com/nexient-llc/git-repo/assets/120601532/d78e1e7c-268f-4211-8e75-f810e9eb296a">

Unit test run cli:
```
docker run -it --rm --name git-repo-test-3-6 -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3.6 python -m pip install pytest && python ./run_tests tests/test_subcmds_envsubst.py
```
```
docker run -it --rm --name git-repo-test-3-6 -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3.6 python -m pip install pytest && python ./run_tests
```

